### PR TITLE
Include itemsPrice in orderModel and remove itemsPrice calculation in OrderScreen

### DIFF
--- a/backend/models/orderModel.js
+++ b/backend/models/orderModel.js
@@ -36,6 +36,11 @@ const orderSchema = mongoose.Schema(
       update_time: { type: String },
       email_address: { type: String },
     },
+    itemsPrice: {
+      type: Number,
+      required: true,
+      default: 0.0,
+    },
     taxPrice: {
       type: Number,
       required: true,

--- a/frontend/src/screens/OrderScreen.js
+++ b/frontend/src/screens/OrderScreen.js
@@ -35,17 +35,6 @@ const OrderScreen = ({ match, history }) => {
   const userLogin = useSelector((state) => state.userLogin)
   const { userInfo } = userLogin
 
-  if (!loading) {
-    //   Calculate prices
-    const addDecimals = (num) => {
-      return (Math.round(num * 100) / 100).toFixed(2)
-    }
-
-    order.itemsPrice = addDecimals(
-      order.orderItems.reduce((acc, item) => acc + item.price * item.qty, 0)
-    )
-  }
-
   useEffect(() => {
     if (!userInfo) {
       history.push('/login')


### PR DESCRIPTION
The reason itemsPrice is not showing in OrderScreen is because it is not saved in the database. When itemsPrice is added in the orderModel, we no longer need to calculate the itemsPrice in OrderScreen.