### PR TITLE
Fixed potential 'TypeError: products.map is not a function' on slow data fetching from DB

### DIFF
--- a/frontend/src/screens/HomeScreen.js
+++ b/frontend/src/screens/HomeScreen.js
@@ -42,11 +42,13 @@ const HomeScreen = ({ match }) => {
       ) : (
         <>
           <Row>
-            {products.map((product) => (
-              <Col key={product._id} sm={12} md={6} lg={4} xl={3}>
-                <Product product={product} />
-              </Col>
-            ))}
+            {products &&
+						products.length &&
+						products.map((product) => (
+							<Col key={product._id} sm={12} md={6} lg={4}>
+								<Product product={product} />
+							</Col>
+						))}
           </Row>
           <Paginate
             pages={pages}


### PR DESCRIPTION
Added some more conditionals to 'products && products.length && ...' to resolve 'TypeError: products.map is not a function' error which can occur if the request to Mongo Atlas for products takes longer than the speed of the page render. Every time I clicked on a product to view it's details, then clicked 'Go Back' or to the homepage I would get 'TypeError: products.map is not a function' consistently until I added the above changes.