### PR TITLE
wrapped item.qty with Number() avoiding string addition issue

### DIFF
--- a/frontend/src/screens/CartScreen.js
+++ b/frontend/src/screens/CartScreen.js
@@ -86,7 +86,7 @@ const CartScreen = ({ match, location, history }) => {
           <ListGroup variant='flush'>
             <ListGroup.Item>
               <h2>
-                Subtotal ({cartItems.reduce((acc, item) => acc + item.qty, 0)})
+                Subtotal ({cartItems.reduce((acc, item) => acc + Number(item.qty), 0)})
                 items
               </h2>
               $


### PR DESCRIPTION
sometimes subtotal adds strings instead of numbers for eg '4' + '6' which should be 10 subtotal, it displays 46. wrapping item.qty in Number() fixes this.