### PR TITLE
Deprecated remove() func Breaks app - Fix, See for details

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -119,7 +119,7 @@ const deleteUser = asyncHandler(async (req, res) => {
   const user = await User.findById(req.params.id)
 
   if (user) {
-    await user.remove()
+    await user.deleteOne()
     res.json({ message: 'User removed' })
   } else {
     res.status(404)


### PR DESCRIPTION
#### DETAILS
- Chapter: 11 Admin Screens -Part 1
- Video: Deleting the Admin User
- TimeStamp:  01:25
 - Location : ```userController.js ``` / ```productController.js```

#### ISSUE
the ```remove()``` function is now deprecated and documentation/  [mongodb  forum](https://www.mongodb.com/community/forums/t/error-message-remove-is-not-a-function-name-typeerror/207387
) advise the use of ```deleteOne()``` or ```deleteMany()```  
#### PROPOSED CHANGE
 The proposed code change makes it so that the app doesn't break. 

**Change any  invocations ( in ```userController.js```/```productController.js``` in the backend) of :**
 ```javascript
remove()
``` 
**To :**
```javascript
deleteOne()
``` 